### PR TITLE
Various updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ ROWND = {
 }
 ```
 
+#### A note on Google Sign-in
+If you plan to use Google sign-in, you'll need to add or update one last configuration item in your 
+`settings.py` while developing locally without HTTPS connections enabled. Without this setting, the
+Google One Tap iframe will not load correctly due to a missing Referrer header.
+
+```
+    SECURE_REFERRER_POLICY = "no-referrer-when-downgrade"
+```
+
+
+
 ### Configure the Rownd Hub (required)
 Rownd authentication requires a small code snippet to be embedded within your app, present on all HTML pages.
 Setup for the Hub/snippet itself is outside the scope of this document, but you can find the relevant setup
@@ -113,7 +124,8 @@ urlpatterns = [
 ]
 ```
 
-Finally, update your Rownd Hub code snippet to fire a post-authenticate API request to the session authenticator we just enabled.
+Finally, update your Rownd Hub code snippet to fire post-authenticate and post-sign-out API requests
+ to the session authenticator we just enabled.
 
 ```html
 <script type="text/javascript">
@@ -142,6 +154,13 @@ Finally, update your Rownd Hub code snippet to fire a post-authenticate API requ
     _rphConfig.push(['setPostAuthenticationApi', {
         method: 'post',
         url: '/rownd/session_authenticate',
+        extra_headers: {
+            'X-CSRFToken': getCookie('csrftoken')
+        }
+    }]);
+    _rphConfig.push(['setPostSignOutApi', {
+        method: 'post',
+        url: '/rownd/session_post_sign_out',
         extra_headers: {
             'X-CSRFToken': getCookie('csrftoken')
         }

--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ Google One Tap iframe will not load correctly due to a missing Referrer header.
     SECURE_REFERRER_POLICY = "no-referrer-when-downgrade"
 ```
 
-
-
 ### Configure the Rownd Hub (required)
 Rownd authentication requires a small code snippet to be embedded within your app, present on all HTML pages.
 Setup for the Hub/snippet itself is outside the scope of this document, but you can find the relevant setup
@@ -174,7 +172,7 @@ the desired authenticated context. In the event that an authenticated session al
 further page refreshes.
 
 #### CSRF Protection
-By d efault CSRF protection is disabled on the two sign-in and sign-out routes provided by Rownd. If
+By default CSRF protection is disabled on the two sign-in and sign-out routes provided by Rownd. If
 you would like to enable it on those endpoints, you must ensure all of your sites views contain the
 `csrftoken` cookie and update your settings to enable the CSRF protection. You can find more information
 on the `csrftoken` cookie [here](https://docs.djangoproject.com/en/4.2/ref/csrf/).

--- a/README.md
+++ b/README.md
@@ -172,3 +172,17 @@ The session authenticator will establish an authenticated session if one doesn't
 indicating that the Rownd Hub should trigger a page refresh. This is usually necessary for your app views to display
 the desired authenticated context. In the event that an authenticated session already exists, the Hub will not trigger
 further page refreshes.
+
+#### CSRF Protection
+By d efault CSRF protection is disabled on the two sign-in and sign-out routes provided by Rownd. If
+you would like to enable it on those endpoints, you must ensure all of your sites views contain the
+`csrftoken` cookie and update your settings to enable the CSRF protection. You can find more information
+on the `csrftoken` cookie [here](https://docs.djangoproject.com/en/4.2/ref/csrf/).
+```python
+ROWND = {
+    'APP_KEY': '<your app key>',
+    'APP_SECRET': '<your app secret>',
+    'CSRF_PROTECT_ROUTES': True
+}
+```
+    

--- a/example/rownd/settings.py
+++ b/example/rownd/settings.py
@@ -26,8 +26,12 @@ SECRET_KEY = 'django-insecure-$&^*o0k+a1(-mtng4)#ub+h#brb($vy+u!u5svb#h95a%-2g7y
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = [
+    "localhost"
+]
 
+# For google One Tap to work
+SECURE_REFERRER_POLICY = "no-referrer-when-downgrade"
 
 # Application definition
 

--- a/example/rownd/templates/test.html
+++ b/example/rownd/templates/test.html
@@ -3,6 +3,7 @@
 <p>You are currently {{ is_authenticated|yesno:"authenticated,not authenticated" }}</p>
 {% if is_authenticated %}
 <p>Authenticated as {{ user.email }}</p>
+<p>User data: {{ user }}</p>
 <p id="api-resp-sample"></p>
 {% endif %}
 
@@ -10,7 +11,7 @@
     (function () {
         var _rphConfig = (window._rphConfig =
             window._rphConfig || []);
-        let baseUrl = window.localStorage.getItem('rph_base_url_override') || 'https://hub.rownd.workers.dev';
+        let baseUrl = window.localStorage.getItem('rph_base_url_override') || 'https://hub.rownd.io';
         _rphConfig.push(['setBaseUrl', baseUrl]);
         var d = document,
             g = d.createElement('script'),
@@ -48,6 +49,13 @@
     _rphConfig.push(['setPostAuthenticationApi', {
         method: 'post',
         url: '/rownd/session_authenticate',
+        extra_headers: {
+            'X-CSRFToken': getCookie('csrftoken')
+        }
+    }]);
+    _rphConfig.push(['setPostSignOutApi', {
+        method: 'post',
+        url: '/rownd/session_sign_out',
         extra_headers: {
             'X-CSRFToken': getCookie('csrftoken')
         }

--- a/example/rownd/views.py
+++ b/example/rownd/views.py
@@ -43,7 +43,6 @@ def rownd_authenticate(request):
     token = token.split(" ")[1]
     
     user = authenticate(request, token=token)
-    print(user)
     if user is not None:
         login(request, user)
         return HttpResponse(status=200, content=json.dumps({ 'message': 'Authentication successful', 'should_refresh_page': True }))
@@ -51,4 +50,7 @@ def rownd_authenticate(request):
         return HttpResponse(status=401)
 
 def check_auth(request):
-    return render(request, 'test.html', { 'is_authenticated': request.user.is_authenticated, 'user': request.user })
+    return render(request, 'test.html', {
+        'is_authenticated': request.user.is_authenticated,
+        'user': request.user
+    })

--- a/rownd_django/__init__.py
+++ b/rownd_django/__init__.py
@@ -4,4 +4,4 @@ import django
 __version__ = "1.0.1"
 
 if django.VERSION < (3, 2):
-    default_app_config = "rownd_django.apps.RowndDjango"
+    default_app_config = "rownd_django.apps.RowndDjangoConfig"

--- a/rownd_django/apps.py
+++ b/rownd_django/apps.py
@@ -1,5 +1,10 @@
 from django.apps import AppConfig
 
-class RowndDjango(AppConfig):
+from .auth import client
+
+class RowndDjangoConfig(AppConfig):
     name = 'rownd_django'
     verbose_name = 'Rownd'
+    def ready(self):
+        # Fetch the Rownd app's app config at startup
+        client.RowndAppConfig().config

--- a/rownd_django/auth/backend.py
+++ b/rownd_django/auth/backend.py
@@ -26,7 +26,12 @@ class RowndAuthBackend:
             except User.DoesNotExist:
                 # create the user
                 try:
-                    user = User(username=token_info["sub"], email=rownd_user["data"]["email"], first_name=rownd_user["data"].get("first_name", ""), last_name=rownd_user["data"].get("last_name", ""))
+                    user = User(
+                        username=token_info["sub"],
+                        email=rownd_user["data"]["email"],
+                        first_name=rownd_user["data"].get("first_name", ""),
+                        last_name=rownd_user["data"].get("last_name", "")
+                    )
                     user.save()
                     return user
                 

--- a/rownd_django/auth/cache.py
+++ b/rownd_django/auth/cache.py
@@ -1,0 +1,26 @@
+import asyncio
+from django.core.cache import cache
+import time
+
+class RowndCache:
+    def fetch(self, cache_key: str, return_val_fn: any, ttl: int):
+        cache_val = cache.get(cache_key)
+        if cache_val is None:
+            return_val = return_val_fn()
+            cache.set(cache_key, [return_val, time.time()])
+            return return_val
+        else:
+            return_val = cache_val[0]
+            last_fetch_time = cache_val[1]
+
+            # Start a new thread to update the cached value if the TTL is exceeded
+            if time.time() - last_fetch_time > ttl:
+              new_val = return_val_fn()
+              if new_val:
+                asyncio.run(self.cache_set_coroutine(cache_key, [new_val, time.time()]))
+            
+            return return_val
+
+    @asyncio.coroutine
+    def cache_set_coroutine(self, cache_key: str, cache_val: any):
+        cache.set(cache_key, cache_val)

--- a/rownd_django/auth/urls.py
+++ b/rownd_django/auth/urls.py
@@ -4,4 +4,5 @@ from . import views
 app_name = 'rownd_django'
 urlpatterns = [
     path('session_authenticate', views.session_authenticate, name='session_authenticate'),
+    path('session_sign_out', views.session_sign_out, name='session_sign_out'),
 ]

--- a/rownd_django/auth/views.py
+++ b/rownd_django/auth/views.py
@@ -6,7 +6,7 @@ from django.views.decorators.csrf import csrf_exempt
 from rownd_django.settings import rownd_settings
 
 def conditional_csrf_exempt(func):
-    if rownd_settings.CSRF_PROTECT_POST_AUTHENTICATION == True:
+    if rownd_settings.CSRF_PROTECT_ROUTES == True:
         # Do not apply the decorator to the function
         return func
     else:

--- a/rownd_django/auth/views.py
+++ b/rownd_django/auth/views.py
@@ -16,8 +16,8 @@ def conditional_csrf_exempt(func):
 @conditional_csrf_exempt
 @require_POST
 def session_authenticate(request):
-    # if request.user.is_authenticated:
-    #     return HttpResponse(status=200, content=json.dumps({ 'message': 'Already authenticated' }))
+    if request.user.is_authenticated:
+        return HttpResponse(status=200, content=json.dumps({ 'message': 'Already authenticated' }))
 
     token = request.headers.get("Authorization")
 

--- a/rownd_django/settings.py
+++ b/rownd_django/settings.py
@@ -18,6 +18,7 @@ DEFAULTS = {
     'API_URL': 'https://api.rownd.io',
     'APP_KEY': os.environ.get("ROWND_APP_KEY") or None,
     'APP_SECRET': os.environ.get("ROWND_APP_KEY") or None,
+    'CSRF_PROTECT_POST_AUTHENTICATION': False,
 }
 
 

--- a/rownd_django/settings.py
+++ b/rownd_django/settings.py
@@ -18,7 +18,7 @@ DEFAULTS = {
     'API_URL': 'https://api.rownd.io',
     'APP_KEY': os.environ.get("ROWND_APP_KEY") or None,
     'APP_SECRET': os.environ.get("ROWND_APP_KEY") or None,
-    'CSRF_PROTECT_POST_AUTHENTICATION': False,
+    'CSRF_PROTECT_ROUTES': False,
 }
 
 


### PR DESCRIPTION
* CSRF_PROTECT_ROUTES setting and default disabling of CSRF protection on session routes.
* Add a sign-out API
* Add a caching class, used specifically for app config caching
* Add SECURE_REFERRER_POLICY setting to example app and documentation to resolve broken Google Sign-ins through One Tap